### PR TITLE
Add aws:setup Command for Automated AWS Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,49 +10,67 @@ You can install the package via composer:
 composer require webmavens/laravelscandocument
 ```
 
-## Usage
-
-- Please create SNS topic in your amazon account.
-
-- How to create one ? 
-
-* Please create IAM Role for textract. Follow this [link](https://docs.aws.amazon.com/textract/latest/dg/api-async-roles.html#api-async-roles-all-topics).
-
-* Please create SNS topic by searching SNS in your aws account.
-
-* After creating topic, please add subscribe url to SNS topic below.
-
-**Note :- Please do not set up raw message delivery for callback url.**
-
-```php
-https://{YOUR_DOMAIN_NAME}/textractCallback
-```
-
-- Please add below parameters to your .env file.
-
-```php
-AWS_DEFAULT_REGION = 'YOUR_AWS_DEFAULT_REGION',
-AWS_ACCESS_KEY_ID = 'YOUR_AWS_ACCESS_KEY_ID',
-AWS_SECRET_ACCESS_KEY = 'YOUR_AWS_SECRET_ACCESS_KEY',
-AWS_BUCKET = 'YOUR_AWS_BUCKET',
-AWS_ARN_TOPIC_ID = 'YOUR_AWS_ARN_TOPIC_ID',
-AWS_SNS_TOPIC_ID = 'YOUR_AWS_SNS_TOPIC_ID',
-```
-
-- Please publish migrate file.
+Publish migrate file.
 
 ```php
 php artisan vendor:publish --tag="laravelscandocument-migrations"
 ```
 
+```php
+php artisan migrate
+```
+
+## AWS Setup (Automatic)
+
+This package includes a powerful command that will automatically create and configure all required AWS resources for you — including:
+
+- S3 Bucket (for document storage)
+- SNS Topic (for Textract notifications)
+- IAM Role (for Textract permissions)
+- IAM User (with access keys)
+
+All credentials and ARNs will be automatically written into your .env file.
+
+## Run the setup command
+
+```php
+php artisan aws:setup
+```
+
+You’ll be asked for your AWS Admin Access Key, Secret Key, and Region.
+
+Once the command completes, it will output details of the created AWS resources and save the following environment variables automatically:
+
+```php
+AWS_ACCESS_KEY_ID=YOUR_NEW_ACCESS_KEY
+AWS_SECRET_ACCESS_KEY=YOUR_NEW_SECRET_KEY
+AWS_DEFAULT_REGION=YOUR_REGION
+AWS_BUCKET=YOUR_BUCKET_NAME
+AWS_SNS_TOPIC_ID=YOUR_SNS_TOPIC_ARN
+AWS_ARN_TOPIC_ID=YOUR_TEXTRACT_ROLE_ARN
+```
+
+## Callback URL
+
+When the command creates your SNS topic, it automatically subscribes your callback endpoint:
+```php
+https://{YOUR_DOMAIN_NAME}/textractCallback
+```
+
+**Note :- Please do not set up raw message delivery for callback url.**
+
+## Usage
+
 - Send document to scan
 
 ```php
-$laravelScandocument = new Webmavens\LaravelScandocument();
-// $path = File path
+$laravelScandocument = new \Webmavens\LaravelScandocument\LaravelScandocument();
+// $path = File path from s3 eg. uploads/test.jpg
 // $jobtag = Type of document
-$response = $laravelScandocument->sendDocToScan($path,$jobtag); //$jobtag is optional.It should be string.
+$response = $laravelScandocument->sendDocToScan($path, $jobtag); //$jobtag is optional.It should be string.
 ```
+- This will upload your document to AWS Textract and process it automatically and return JOBID in response.
+- You’ll receive the extracted data via your SNS callback endpoint (/textractCallback).
 
 - You will find scan document text in **laravel_scandocument_data** table.
 

--- a/src/Commands/SetupAwsCommand.php
+++ b/src/Commands/SetupAwsCommand.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace Webmavens\LaravelScandocument\Commands;
+
+use Aws\Iam\IamClient;
+use Aws\Sns\SnsClient;
+use Aws\Sts\StsClient;
+use Aws\S3\S3Client;
+use Aws\Exception\AwsException;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Validator;
+
+class SetupAwsCommand extends Command
+{
+    protected $signature = 'aws:setup';
+    protected $description = 'Setup AWS resources using admin keys and create IAM user';
+
+    public function handle()
+    {
+        // Step 0: Ask for admin credentials
+        $adminKey = $this->askValid(
+            'What is your ADMIN aws access key?',
+            'aws_admin_key',
+            ['required'],
+            ''
+        );
+
+        $adminSecret = $this->askValid(
+            'What is your ADMIN aws secret access key?',
+            'aws_secret_key',
+            ['required'],
+            ''
+        );
+
+        $region = $this->askValid(
+            'What is your aws region?',
+            'aws_region_key',
+            ['required'],
+            'us-east-1'
+        );
+
+        $appName = env('APP_NAME') ?: 'Laravel';
+        $appUrl = env('APP_URL');
+        $this->info('Starting AWS setup...');
+
+        // ---------- Step 1: Create S3 Bucket using admin credentials ----------
+        $s3Client = new S3Client([
+            'version' => 'latest',
+            'region' => $region,
+            'credentials' => [
+                'key' => $adminKey,
+                'secret' => $adminSecret,
+            ],
+        ]);
+
+        $bucketName = strtolower($appName . '-public-' . uniqid());
+
+        try {
+            $s3Client->createBucket([
+                'Bucket' => $bucketName,
+                'CreateBucketConfiguration' => ['LocationConstraint' => $region],
+            ]);
+
+            // Disable block public access
+            $s3Client->putPublicAccessBlock([
+                'Bucket' => $bucketName,
+                'PublicAccessBlockConfiguration' => [
+                    'BlockPublicAcls' => false,
+                    'IgnorePublicAcls' => false,
+                    'BlockPublicPolicy' => false,
+                    'RestrictPublicBuckets' => false,
+                ],
+            ]);
+
+            // Then you can attach public-read policy
+            $policy = [
+                'Version' => '2012-10-17',
+                'Statement' => [
+                    [
+                        'Sid' => 'PublicReadGetObject',
+                        'Effect' => 'Allow',
+                        'Principal' => '*',
+                        'Action' => 's3:GetObject',
+                        'Resource' => "arn:aws:s3:::{$bucketName}/*",
+                    ],
+                ],
+            ];
+
+            $s3Client->putBucketPolicy([
+                'Bucket' => $bucketName,
+                'Policy' => json_encode($policy),
+            ]);
+
+            $this->info("S3 Bucket {$bucketName} created with public read access.");
+        } catch (AwsException $e) {
+            $this->error("S3 Error: " . $e->getMessage());
+            return;
+        }
+
+        // ---------- Step 2: Create SNS Topic using admin credentials ----------
+        $snsClient = new SnsClient([
+            'version' => 'latest',
+            'region' => $region,
+            'credentials' => [
+                'key' => $adminKey,
+                'secret' => $adminSecret,
+            ],
+        ]);
+
+        $sts = new StsClient([
+            'version' => '2011-06-15',
+            'region' => $region,
+            'credentials' => [
+                'key' => $adminKey,
+                'secret' => $adminSecret,
+            ],
+        ]);
+
+        $accountId = $sts->getCallerIdentity()['Account'];
+        $snsTopicName = strtolower($appName . '-sns-' . uniqid());
+        $snsEndpointURL = $appUrl . '/textractCallback';
+
+        try {
+            $topic = $snsClient->createTopic(['Name' => $snsTopicName]);
+            $topicArn = $topic['TopicArn'];
+
+            $snsPolicy = [
+                'Version' => '2008-10-17',
+                'Id' => '__default_policy_ID',
+                'Statement' => [
+                    [
+                        'Sid' => '__default_statement_ID',
+                        'Effect' => 'Allow',
+                        'Principal' => ['Service' => 'textract.amazonaws.com'],
+                        'Action' => 'SNS:Publish',
+                        'Resource' => "arn:aws:sns:{$region}:{$accountId}:{$snsTopicName}",
+                    ],
+                    [
+                        'Sid' => 'AllowOwnerAccess',
+                        'Effect' => 'Allow',
+                        'Principal' => ['AWS' => '*'],
+                        'Action' => [
+                            'SNS:GetTopicAttributes',
+                            'SNS:SetTopicAttributes',
+                            'SNS:AddPermission',
+                            'SNS:RemovePermission',
+                            'SNS:DeleteTopic',
+                            'SNS:Subscribe',
+                            'SNS:ListSubscriptionsByTopic',
+                            'SNS:Publish',
+                            'SNS:Receive',
+                        ],
+                        'Resource' => "arn:aws:sns:{$region}:{$accountId}:{$snsTopicName}",
+                    ],
+                ],
+            ];
+
+            $snsClient->setTopicAttributes([
+                'TopicArn'       => $topicArn,
+                'AttributeName'  => 'Policy',
+                'AttributeValue' => json_encode($snsPolicy),
+            ]);
+
+            $snsClient->subscribe([
+                'TopicArn' => $topicArn,
+                'Protocol' => 'https',
+                'Endpoint' => $snsEndpointURL,
+            ]);
+
+            $this->info("SNS Topic {$snsTopicName} created: {$topicArn}");
+        } catch (AwsException $e) {
+            $this->error("SNS Error: " . $e->getMessage());
+            return;
+        }
+
+        // ---------- Step 3: Create Textract Role using admin credentials ----------
+        $iamClient = new IamClient([
+            'version' => 'latest',
+            'region' => $region,
+            'credentials' => [
+                'key' => $adminKey,
+                'secret' => $adminSecret,
+            ],
+        ]);
+
+        $roleName = strtolower($appName . '-textract-' . uniqid());
+        $trustPolicy = [
+            'Version' => '2012-10-17',
+            'Statement' => [
+                [
+                    'Effect'    => 'Allow',
+                    'Principal' => ['Service' => 'textract.amazonaws.com'],
+                    'Action'    => 'sts:AssumeRole',
+                ],
+            ],
+        ];
+
+        try {
+            $role = $iamClient->createRole([
+                'RoleName'                 => $roleName,
+                'AssumeRolePolicyDocument' => json_encode($trustPolicy),
+            ]);
+
+            $iamClient->attachRolePolicy([
+                'RoleName'  => $roleName,
+                'PolicyArn' => 'arn:aws:iam::aws:policy/AmazonTextractFullAccess',
+            ]);
+
+            $publishPolicy = [
+                'Version' => '2012-10-17',
+                'Statement' => [
+                    [
+                        'Effect'   => 'Allow',
+                        'Action'   => 'sns:Publish',
+                        'Resource' => $topicArn,
+                    ],
+                ],
+            ];
+
+            $iamClient->putRolePolicy([
+                'RoleName'       => $roleName,
+                'PolicyName'     => 'TextractSNSTopicPublishAccess',
+                'PolicyDocument' => json_encode($publishPolicy),
+            ]);
+
+            $this->info("Textract Role {$roleName} created: {$role['Role']['Arn']}");
+        } catch (AwsException $e) {
+            $this->error("IAM Role Error: " . $e->getMessage());
+            return;
+        }
+
+        // ---------- Step 4: Create IAM User and attach policies ----------
+        $userName = strtolower($appName . '-user-' . uniqid());
+
+        try {
+            $user = $iamClient->createUser(['UserName' => $userName]);
+
+            // Attach AdministratorAccess for simplicity (or attach fine-grained policies)
+            $iamClient->attachUserPolicy([
+                'UserName' => $userName,
+                'PolicyArn' => 'arn:aws:iam::aws:policy/AdministratorAccess',
+            ]);
+
+            $accessKey = $iamClient->createAccessKey(['UserName' => $userName]);
+            $awsAccessKey = $accessKey['AccessKey']['AccessKeyId'];
+            $awsSecretKey = $accessKey['AccessKey']['SecretAccessKey'];
+
+            $this->info("IAM User {$userName} created and access keys generated.");
+        } catch (AwsException $e) {
+            $this->error("IAM User Error: " . $e->getMessage());
+            return;
+        }
+
+        // ---------- Step 5: Save all environment variables ----------
+        $this->setEnvironmentValue([
+            'AWS_ACCOUNT_ID'        => $accountId,
+            'AWS_ACCESS_KEY_ID'     => $awsAccessKey,
+            'AWS_SECRET_ACCESS_KEY' => $awsSecretKey,
+            'AWS_DEFAULT_REGION'    => $region,
+            'AWS_BUCKET'            => $bucketName,
+            'AWS_SNS_TOPIC_ID'      => $topicArn,
+            'AWS_ARN_TOPIC_ID'      => $role['Role']['Arn'],
+        ]);
+
+        $this->info('✅ AWS setup completed successfully.');
+    }
+
+    protected function setEnvironmentValue(array $values)
+    {
+        $envFile = base_path('.env');
+        $content = file_get_contents($envFile);
+
+        foreach ($values as $key => $value) {
+            if (preg_match("/^{$key}=.*$/m", $content)) {
+                $content = preg_replace("/^{$key}=.*$/m", "{$key}={$value}", $content);
+            } else {
+                $content .= "\n{$key}={$value}";
+            }
+        }
+
+        file_put_contents($envFile, $content);
+        \Artisan::call('config:clear');
+    }
+
+    protected function askValid($question, $field, $rules, $defaultValue)
+    {
+        $value = $this->ask($question, $defaultValue);
+
+        if ($message = $this->validateInput($rules, $field, $value)) {
+            $this->error($message);
+
+            return $this->askValid($question, $field, $rules, $defaultValue);
+        }
+
+        return $value;
+    }
+
+    protected function validateInput($rules, $fieldName, $value)
+    {
+        $validator = Validator::make([
+            $fieldName => $value,
+        ], [
+            $fieldName => $rules,
+        ]);
+
+        return $validator->fails()
+            ? $validator->errors()->first($fieldName)
+            : null;
+    }
+}

--- a/src/LaravelScandocumentServiceProvider.php
+++ b/src/LaravelScandocumentServiceProvider.php
@@ -4,6 +4,7 @@ namespace Webmavens\LaravelScandocument;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Webmavens\LaravelScandocument\Commands\SetupAwsCommand;
 
 class LaravelScandocumentServiceProvider extends PackageServiceProvider
 {
@@ -18,6 +19,7 @@ class LaravelScandocumentServiceProvider extends PackageServiceProvider
             ->name('laravelscandocument')
             ->hasConfigFile()
             ->hasMigration('create_laravelscandocument_table')
-            ->hasRoute('web');
+            ->hasRoute('web')
+            ->hasCommand(SetupAwsCommand::class);
     }
 }


### PR DESCRIPTION
Related Issue: #1 

## Description

This PR introduces a new Artisan command — `aws:setup` — that automates the entire AWS setup process required for the Laravel Scan Document package.
